### PR TITLE
feat: player improvements and custom dictionary

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "latest"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.13.tgz",
+      "integrity": "sha512-zHgtWfdDz8Wu8srE8f8HUtPT9i6c3jTmgQKoFZUZ+RR5CMQF1kAlb1cxeEe9Xm2DRNFVJog9Cv/G1iUHYgXSUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.3.13",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.95",
+        "@opentui/solid": ">=0.1.95"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.13.tgz",
+      "integrity": "sha512-/M6HlNnba+xf1EId6qFb2tG0cvq0db3PCQDug1glrf8wYOU57LYNF8WvHX9zoDKPTMv0F+O4pcP/8J+WvDaxHA==",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/DRIVE_SYNC_STATUS_TRACE.md
+++ b/DRIVE_SYNC_STATUS_TRACE.md
@@ -1,0 +1,396 @@
+# Drive Sync Component Status: Complete Code Path Trace
+
+## Executive Summary
+
+The "Drive Sync:error" status shown in the UI is produced by **sync orchestrator callbacks in the session manager** when Google Drive sync fails. The status flows through the websocket event system and is consumed by the frontend state management.
+
+---
+
+## Backend: Status Production
+
+### 1. **Source: Session Manager** (`internal/session/manager.go`)
+
+The sync status is set in **two locations** within the session end flow:
+
+#### Location A: After Quick Refinement (lines 383-396)
+```go
+if syncer != nil {
+    go func() {
+        if err := syncer.SyncSession(context.Background(), sessionID); err != nil {
+            m.logger.Error("gdrive sync failed", "operation", "sync_session", "session_id", sessionID, "error", err)
+            if m.hub != nil {
+                m.hub.BroadcastComponentStatus("sync", storage.ComponentStatusError, fmt.Sprintf("Google Drive sync failed for session %s", sessionID))
+            }
+            return
+        }
+        if m.hub != nil {
+            m.hub.BroadcastComponentStatus("sync", storage.ComponentStatusConnected, fmt.Sprintf("Google Drive sync completed for session %s", sessionID))
+        }
+    }()
+}
+```
+
+#### Location B: After Full Summarization (lines 465-478)
+```go
+if syncer != nil {
+    go func() {
+        if err := syncer.SyncSession(context.Background(), sessionID); err != nil {
+            m.logger.Error("gdrive sync failed", "operation", "sync_session", "session_id", sessionID, "error", err)
+            if m.hub != nil {
+                m.hub.BroadcastComponentStatus("sync", storage.ComponentStatusError, fmt.Sprintf("Google Drive sync failed for session %s", sessionID))
+            }
+            return
+        }
+        if m.hub != nil {
+            m.hub.BroadcastComponentStatus("sync", storage.ComponentStatusConnected, fmt.Sprintf("Google Drive sync completed for session %s", sessionID))
+        }
+    }()
+}
+```
+
+**Key Points:**
+- Status is set **asynchronously** via goroutine after session ends
+- Error status is set when `syncer.SyncSession()` returns an error
+- Success status is set when sync completes without error
+- The `syncer` is injected into the manager (likely a Google Drive sync orchestrator)
+
+### 2. **Event Broadcasting: Hub** (`internal/server/hub.go`)
+
+The `BroadcastComponentStatus` method (lines 141-154):
+
+```go
+func (h *Hub) BroadcastComponentStatus(component, status, message string) {
+    event := ComponentStatusEvent{
+        Event:     newEvent("component_status", time.Now().UTC()),
+        Component: component,
+        Status:    status,
+        Message:   message,
+    }
+
+    h.mu.Lock()
+    h.componentStatuses[component] = event  // Store latest status
+    h.mu.Unlock()
+
+    h.broadcastEvent(event)  // Send to all connected clients
+}
+```
+
+**Key Points:**
+- Stores the **latest status** in `componentStatuses` map (keyed by component name)
+- Broadcasts to all connected websocket clients
+- Event is persisted to event store if configured
+
+### 3. **Event Type Definition** (`internal/server/events.go`)
+
+```go
+type ComponentStatusEvent struct {
+    Event
+    Component string `json:"component"`
+    Status    string `json:"status"`
+    Message   string `json:"message"`
+}
+```
+
+### 4. **Status Constants** (`internal/status/status.go`)
+
+```go
+const (
+    ComponentStatusConnected    = "connected"
+    ComponentStatusDisconnected = "disconnected"
+    ComponentStatusReconnecting = "reconnecting"
+    ComponentStatusError        = "error"
+    ComponentStatusOK           = "ok"
+    ComponentStatusOpen         = "open"
+    ComponentStatusClosed       = "closed"
+)
+```
+
+---
+
+## WebSocket Transport
+
+### 1. **Connection Handler** (`internal/server/ws.go`, lines 18-57)
+
+When a client connects:
+
+```go
+// 1. Send connection event
+connectionEvent := ConnectionEvent{
+    Event:     newEvent("connection", time.Now().UTC()),
+    Connected: true,
+}
+payload, err := json.Marshal(connectionEvent)
+if err == nil {
+    _ = conn.WriteMessage(websocket.TextMessage, payload)
+}
+
+// 2. Subscribe to future events
+ch := hub.Subscribe()
+defer hub.Unsubscribe(ch)
+
+// 3. Send snapshot of current component statuses
+for _, statusEvent := range hub.SnapshotComponentStatuses() {
+    payload, err := json.Marshal(statusEvent)
+    if err != nil {
+        continue
+    }
+    if err := conn.WriteMessage(websocket.TextMessage, payload); err != nil {
+        return
+    }
+}
+
+// 4. Stream future events
+for msg := range ch {
+    if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+        return
+    }
+}
+```
+
+**Key Points:**
+- **Snapshot sent on connection** - all current component statuses are sent immediately
+- **Future events streamed** - new status changes are sent as they occur
+- This is why the UI shows the error even if it happened before the page loaded
+
+---
+
+## Frontend: Status Consumption
+
+### 1. **State Management** (`web/src/lib/state.svelte.ts`)
+
+#### State Definition (lines 12-16, 32)
+```typescript
+export type ComponentStatus = {
+  status: ComponentStatusValue
+  message: string
+  timestamp: string
+}
+
+type AppState = {
+  // ...
+  componentStatuses: Record<string, ComponentStatus>
+}
+```
+
+#### Event Handler (lines 176-178)
+```typescript
+case 'component_status':
+  applyComponentStatus(event)
+  return
+```
+
+#### Status Application (lines 184-193)
+```typescript
+export function applyComponentStatus(event: ComponentStatusEvent): void {
+  appState.componentStatuses = {
+    ...appState.componentStatuses,
+    [event.component]: {
+      status: event.status,
+      message: event.message,
+      timestamp: event.timestamp,
+    },
+  }
+}
+```
+
+### 2. **UI Rendering** (`web/src/components/SystemStatus.svelte`)
+
+#### Status Retrieval (line 6)
+```typescript
+const syncStatus = $derived(appState.componentStatuses['sync'])
+```
+
+#### Status Display (lines 96-101)
+```svelte
+<div class="status-item" data-testid="status-sync">
+  <span class="status-dot" style="background-color: {getStatusColor(syncStatus?.status)}"></span>
+  <span class="status-label" style="color: {getStatusColor(syncStatus?.status)}"
+    >Drive Sync: {syncStatus?.status || 'unknown'}</span
+  >
+</div>
+```
+
+#### Color Mapping (lines 10-30)
+```typescript
+function getStatusColor(status?: ComponentStatus) {
+  switch (status) {
+    case ComponentStatus.Connected:
+    case ComponentStatus.Synced:
+    case ComponentStatus.Open:
+    case ComponentStatus.Ok:
+      return 'var(--success)'
+    case ComponentStatus.Unavailable:
+    case ComponentStatus.Disabled:
+    case ComponentStatus.Closed:
+      return 'var(--warning)'
+    case ComponentStatus.Disconnected:
+    case ComponentStatus.Error:
+      return 'var(--danger)'
+    // ...
+  }
+}
+```
+
+**Key Points:**
+- `ComponentStatus.Error` maps to `var(--danger)` (red color)
+- Status is derived reactively from `appState.componentStatuses['sync']`
+- Message is stored but not displayed in the status header
+
+---
+
+## Complete Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ BACKEND: Session End Flow                                       │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  1. Session ends (quick refinement or full summarization)      │
+│  2. syncer.SyncSession(sessionID) called asynchronously        │
+│  3. If error:                                                   │
+│     → hub.BroadcastComponentStatus(                            │
+│         "sync",                                                 │
+│         storage.ComponentStatusError,  // = "error"            │
+│         "Google Drive sync failed for session {id}"            │
+│       )                                                         │
+│  4. If success:                                                 │
+│     → hub.BroadcastComponentStatus(                            │
+│         "sync",                                                 │
+│         storage.ComponentStatusConnected,  // = "connected"    │
+│         "Google Drive sync completed for session {id}"         │
+│       )                                                         │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ HUB: Event Storage & Broadcasting                               │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  1. Store in componentStatuses["sync"] = event                 │
+│  2. Broadcast to all connected websocket clients               │
+│  3. Persist to event store (if configured)                     │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ WEBSOCKET: Transport                                            │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  On new connection:                                             │
+│  1. Send connection event                                       │
+│  2. Send snapshot of all current component statuses             │
+│     (includes latest sync status)                               │
+│  3. Stream future status changes                                │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ FRONTEND: State Management                                      │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  1. Receive component_status event                              │
+│  2. applyComponentStatus() updates appState:                    │
+│     appState.componentStatuses['sync'] = {                      │
+│       status: "error",                                          │
+│       message: "Google Drive sync failed for session {id}",     │
+│       timestamp: "2026-04-11T..."                               │
+│     }                                                           │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ FRONTEND: UI Rendering                                          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  1. syncStatus = appState.componentStatuses['sync']             │
+│  2. Display: "Drive Sync: error"                                │
+│  3. Color: getStatusColor("error") → var(--danger) [RED]        │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Key Findings
+
+### Source of "Drive Sync:error"
+
+**Primary Source:** `syncer.SyncSession()` error in `internal/session/manager.go`
+
+- **Trigger:** When a session ends (either quick refinement or full summarization)
+- **Condition:** The Google Drive sync orchestrator returns an error
+- **Execution:** Asynchronous goroutine (non-blocking)
+- **Status Value:** `storage.ComponentStatusError` = `"error"`
+
+### Why It Persists
+
+1. **Status is stored** in `hub.componentStatuses["sync"]`
+2. **Snapshot sent on connection** - any new client receives the last known status
+3. **No automatic recovery** - status remains until explicitly changed by another sync attempt
+
+### Related Status Sources
+
+Other components that set status via `BroadcastComponentStatus`:
+
+| Component | Source | Trigger |
+|-----------|--------|---------|
+| `mic` | `cmd/ghost-wispr/main.go` | Microphone connection/disconnection events |
+| `deepgram` | `cmd/ghost-wispr/main.go` | Deepgram resilient client state changes |
+| `summary` | `internal/session/manager.go` | Summarization failures |
+| `refinement` | `internal/session/manager.go` | Batch refinement failures |
+
+### No Health Check Dependency
+
+**Important:** The sync status is **NOT** based on:
+- ❌ Health check endpoints (`/healthz/live`, `/healthz/ready`)
+- ❌ Periodic polling
+- ❌ Component availability checks
+
+It is **purely event-driven** from the sync orchestrator callback.
+
+---
+
+## Files Involved
+
+### Backend
+- `internal/session/manager.go` - **Sync status source** (lines 383-396, 465-478)
+- `internal/server/hub.go` - **Event broadcasting** (lines 141-154)
+- `internal/server/ws.go` - **WebSocket transport** (lines 41-49)
+- `internal/server/events.go` - **Event type definition**
+- `internal/status/status.go` - **Status constants**
+
+### Frontend
+- `web/src/lib/state.svelte.ts` - **State management** (lines 176-193)
+- `web/src/components/SystemStatus.svelte` - **UI rendering** (lines 6, 96-101)
+- `web/src/lib/types.ts` - **Type definitions**
+
+---
+
+## Verification Points
+
+To verify this trace:
+
+1. **Check sync error source:**
+   ```bash
+   grep -n "syncer.SyncSession" internal/session/manager.go
+   ```
+
+2. **Check broadcast calls:**
+   ```bash
+   grep -n 'BroadcastComponentStatus.*"sync"' internal/session/manager.go
+   ```
+
+3. **Check websocket snapshot:**
+   ```bash
+   grep -n "SnapshotComponentStatuses" internal/server/ws.go
+   ```
+
+4. **Check frontend state update:**
+   ```bash
+   grep -n "applyComponentStatus" web/src/lib/state.svelte.ts
+   ```
+
+5. **Check UI rendering:**
+   ```bash
+   grep -n "syncStatus" web/src/components/SystemStatus.svelte
+   ```

--- a/cmd/ghost-wispr/main.go
+++ b/cmd/ghost-wispr/main.go
@@ -1442,6 +1442,7 @@ User feedback: %s`, current.Description, current.SystemPrompt, current.UserTempl
 			InterimResults: true,
 			UtteranceEndMs: cfg.Transcription.UtteranceEndMs,
 			VadEvents:      true,
+			Keywords:       cfg.Transcription.Keywords,
 		}
 		resilientConfig := transcribe.ResilientConfig{
 			BufferSize:            cfg.DeepgramBufferSize,

--- a/cmd/ghost-wispr/main.go
+++ b/cmd/ghost-wispr/main.go
@@ -183,8 +183,9 @@ func makeBatchTranscriber(cfg *config.Config) (transcribe.BatchTranscriber, erro
 			return nil, fmt.Errorf("deepgram API key not configured")
 		}
 		return transcribe.NewDeepgramBatchTranscriber(transcribe.DeepgramBatchConfig{
-			APIKey: cfg.DeepgramAPIKey,
-			Model:  cfg.BatchTranscription.Model,
+			APIKey:   cfg.DeepgramAPIKey,
+			Model:    cfg.BatchTranscription.Model,
+			Keywords: cfg.Transcription.Keywords,
 		}), nil
 	case "groq", "openai":
 		return nil, fmt.Errorf("batch transcription provider %q is not implemented yet", cfg.BatchTranscription.Provider)

--- a/docs/plans/2026-04-12-player-improvements-and-dictionary.md
+++ b/docs/plans/2026-04-12-player-improvements-and-dictionary.md
@@ -1,0 +1,797 @@
+# Player Improvements & Custom Dictionary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix audio seeking when clicking far into transcripts, add 30-second skip forward/back controls, and add a custom keyword dictionary for transcription.
+
+**Architecture:** Three independent features, each a vertical slice through the Svelte frontend and Go backend. Feature 1 (seek fix) and Feature 2 (skip controls) are frontend-only. Feature 3 (dictionary) spans config, backend Deepgram integration, config API, and settings UI.
+
+**Tech Stack:** Svelte 5 + TypeScript (frontend), Go 1.25+ (backend), Deepgram API (transcription), SQLite (config persistence), Vite (build), vitest (frontend tests), `go test` (backend tests)
+
+**Source:** [Slack message from Peter](https://trajectorylabs.slack.com/archives/C0A5WLJS006/p1775706184332929) — items 2, 3, and 4.
+
+**Test commands:**
+- Backend: `go test ./...`
+- Frontend: `cd web && npm test`
+- Dev server: `cd web && npm run dev` (proxies API to :8080)
+
+---
+
+## Feature 1: Fix Transcript Seek (Bug)
+
+**Bug report:** "If I click far into the transcript, it starts the recording again at 0 seconds."
+
+**Root cause hypothesis:** The audio element uses `preload="metadata"`, so the browser only downloads headers initially. When `seekTo()` sets `audioEl.currentTime` to a position far into the file, the browser must issue a Range request. If the seek target exceeds the buffered/seekable range and the browser can't resolve the byte offset (e.g., VBR MP3 without proper Xing header, or a timing race), it silently resets `currentTime` to 0. Meanwhile, `onTimeUpdate` faithfully reports 0 to the UI. There is no `onseeking`/`onseeked` handler, no validation that the seek succeeded, and no loading indicator during the seek.
+
+**Uncertainty:** The exact failure mode needs empirical confirmation. The plan handles both "seek silently fails" and "seek is slow and UI shows stale time" scenarios.
+
+### Task 1.1: Add seek state tracking and event handlers to AudioPlayer
+
+**Files:**
+- Modify: `web/src/components/AudioPlayer.svelte`
+- Modify: `web/src/components/__tests__/AudioPlayer.test.ts`
+
+- [ ] **Step 1: Write failing tests for seek behavior**
+
+Add tests that verify: (a) clicking a transcript line while audio is loaded triggers seek to the correct time, (b) a `seeking` CSS class is applied during seek, (c) `onTimeUpdate` does not overwrite `currentTime` while seeking.
+
+```typescript
+it('applies seeking class during seek', async () => {
+  const segments = [
+    { start_time: 0, end_time: 30, text: 'Hello', speaker: 0, timestamp: '2026-01-01T00:00:00Z' },
+    { start_time: 300, end_time: 330, text: 'Far segment', speaker: 0, timestamp: '2026-01-01T00:05:00Z' },
+  ]
+  const { container } = render(AudioPlayer, { props: { sessionId: 's1', segments } })
+  const audio = container.querySelector('audio') as HTMLAudioElement
+
+  // Simulate metadata loaded
+  Object.defineProperty(audio, 'duration', { value: 600, writable: true })
+  await audio.dispatchEvent(new Event('loadedmetadata'))
+
+  // Click the far segment
+  const lines = container.querySelectorAll('.line')
+  await fireEvent.click(lines[1])
+
+  // Should show seeking state
+  expect(container.querySelector('.audio-player')?.classList.contains('seeking')).toBe(true)
+
+  // Simulate seeked
+  await audio.dispatchEvent(new Event('seeked'))
+  expect(container.querySelector('.audio-player')?.classList.contains('seeking')).toBe(false)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/components/__tests__/AudioPlayer.test.ts`
+Expected: FAIL — no `seeking` class behavior exists yet.
+
+- [ ] **Step 3: Add seeking state and event handlers**
+
+Modify `AudioPlayer.svelte` to:
+1. Add a `seeking` reactive state variable
+2. Add `onseeking` handler that sets `seeking = true`
+3. Add `onseeked` handler that sets `seeking = false` and syncs `currentTime`
+4. Guard `onTimeUpdate` to skip updates while `seeking` is true
+5. Apply `seeking` CSS class to the player container
+6. In `seekTo()`, also trigger play if audio was already playing (to force the browser to load audio at the seek target)
+
+```svelte
+<script lang="ts">
+  // ... existing code ...
+  let seeking = $state(false)
+
+  function seekTo(seconds: number) {
+    if (!audioEl) return
+    seeking = true
+    audioEl.currentTime = seconds
+    setActiveAudioSession(sessionId)
+  }
+
+  function onSeeking() {
+    seeking = true
+  }
+
+  function onSeeked() {
+    if (!audioEl) return
+    seeking = false
+    currentTime = audioEl.currentTime
+  }
+
+  function onTimeUpdate() {
+    if (!audioEl || seeking) return
+    currentTime = audioEl.currentTime
+  }
+</script>
+
+<div class="audio-player" class:seeking data-testid="audio-player">
+  <audio
+    bind:this={audioEl}
+    src={`/api/sessions/${encodeURIComponent(sessionId)}/audio`}
+    preload="auto"
+    onloadedmetadata={onLoadedMetadata}
+    ontimeupdate={onTimeUpdate}
+    onseeking={onSeeking}
+    onseeked={onSeeked}
+    onplay={() => (playing = true)}
+    onpause={() => (playing = false)}
+    onerror={() => {
+      loading = false
+      error = 'Audio unavailable'
+    }}
+  ></audio>
+  <!-- ... -->
+</div>
+```
+
+Key change: `preload="metadata"` → `preload="auto"`. This ensures the browser downloads the full file, making seeks reliable. These are meeting recordings served from local storage, so bandwidth isn't a concern.
+
+- [ ] **Step 4: Add seeking indicator styling**
+
+In `web/src/app.css`, add a subtle pulsing opacity to the player when seeking:
+
+```css
+.audio-player.seeking .audio-time {
+  opacity: 0.5;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/components/__tests__/AudioPlayer.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Describe and advance**
+
+```bash
+jj describe -m "fix: handle audio seeking state to prevent transcript click resetting to 0s
+
+Add onseeking/onseeked handlers, guard onTimeUpdate during seeks, switch to
+preload=auto for reliable seeking of local audio files."
+jj new
+```
+
+---
+
+## Feature 2: Skip Forward/Back 30 Seconds
+
+### Task 2.1: Add skip buttons to AudioPlayer
+
+**Files:**
+- Modify: `web/src/components/AudioPlayer.svelte`
+- Modify: `web/src/components/__tests__/AudioPlayer.test.ts`
+- Modify: `web/src/app.css`
+
+- [ ] **Step 1: Write failing tests for skip controls**
+
+```typescript
+it('skip back 30s button decrements currentTime', async () => {
+  const segments = [
+    { start_time: 0, end_time: 120, text: 'Long segment', speaker: 0, timestamp: '2026-01-01T00:00:00Z' },
+  ]
+  const { container } = render(AudioPlayer, { props: { sessionId: 's1', segments } })
+  const audio = container.querySelector('audio') as HTMLAudioElement
+  Object.defineProperty(audio, 'duration', { value: 600, writable: true })
+  await audio.dispatchEvent(new Event('loadedmetadata'))
+
+  // Simulate playback at 90s
+  Object.defineProperty(audio, 'currentTime', { value: 90, writable: true, configurable: true })
+  await audio.dispatchEvent(new Event('timeupdate'))
+
+  const skipBack = container.querySelector('[data-testid="skip-back"]') as HTMLButtonElement
+  expect(skipBack).toBeTruthy()
+  await fireEvent.click(skipBack)
+
+  // Should have set currentTime to 60
+  expect(audio.currentTime).toBe(60)
+})
+
+it('skip forward 30s button increments currentTime', async () => {
+  const segments = [
+    { start_time: 0, end_time: 120, text: 'Long segment', speaker: 0, timestamp: '2026-01-01T00:00:00Z' },
+  ]
+  const { container } = render(AudioPlayer, { props: { sessionId: 's1', segments } })
+  const audio = container.querySelector('audio') as HTMLAudioElement
+  Object.defineProperty(audio, 'duration', { value: 600, writable: true })
+  await audio.dispatchEvent(new Event('loadedmetadata'))
+
+  Object.defineProperty(audio, 'currentTime', { value: 90, writable: true, configurable: true })
+  await audio.dispatchEvent(new Event('timeupdate'))
+
+  const skipFwd = container.querySelector('[data-testid="skip-forward"]') as HTMLButtonElement
+  expect(skipFwd).toBeTruthy()
+  await fireEvent.click(skipFwd)
+
+  expect(audio.currentTime).toBe(120)
+})
+
+it('skip back clamps to 0', async () => {
+  const segments = [
+    { start_time: 0, end_time: 120, text: 'Segment', speaker: 0, timestamp: '2026-01-01T00:00:00Z' },
+  ]
+  const { container } = render(AudioPlayer, { props: { sessionId: 's1', segments } })
+  const audio = container.querySelector('audio') as HTMLAudioElement
+  Object.defineProperty(audio, 'duration', { value: 600, writable: true })
+  await audio.dispatchEvent(new Event('loadedmetadata'))
+
+  Object.defineProperty(audio, 'currentTime', { value: 10, writable: true, configurable: true })
+  await audio.dispatchEvent(new Event('timeupdate'))
+
+  const skipBack = container.querySelector('[data-testid="skip-back"]') as HTMLButtonElement
+  await fireEvent.click(skipBack)
+
+  expect(audio.currentTime).toBe(0)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/components/__tests__/AudioPlayer.test.ts`
+Expected: FAIL — no skip buttons exist.
+
+- [ ] **Step 3: Add skip functions and buttons**
+
+In `AudioPlayer.svelte`, add:
+
+```typescript
+function skipBack() {
+  if (!audioEl) return
+  audioEl.currentTime = Math.max(0, audioEl.currentTime - 30)
+  setActiveAudioSession(sessionId)
+}
+
+function skipForward() {
+  if (!audioEl) return
+  audioEl.currentTime = Math.min(duration, audioEl.currentTime + 30)
+  setActiveAudioSession(sessionId)
+}
+```
+
+Update the controls section (between the play button and time display):
+
+```svelte
+<div class="audio-controls">
+  <button type="button" class="audio-btn" onclick={skipBack} data-testid="skip-back" title="Back 30s">
+    -30s
+  </button>
+  <button type="button" class="audio-btn" onclick={togglePlay}>
+    {playing ? 'Pause' : 'Play'}
+  </button>
+  <button type="button" class="audio-btn" onclick={skipForward} data-testid="skip-forward" title="Forward 30s">
+    +30s
+  </button>
+  <span class="audio-time">{prettyTime(currentTime)} / {prettyTime(duration)}</span>
+</div>
+```
+
+Note: also shorten the play/pause label from "Play Audio"/"Pause Audio" to "Play"/"Pause" since the button context is now clearer with adjacent skip controls. Update the existing test in `AudioPlayer.test.ts` line 24 that checks for `'Play Audio'` to use `'Play'` instead.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/components/__tests__/AudioPlayer.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Verify existing tests still pass**
+
+Run: `cd web && npx vitest run`
+Expected: All tests PASS
+
+- [ ] **Step 6: Describe and advance**
+
+```bash
+jj describe -m "feat: add 30-second skip forward/back controls to audio player"
+jj new
+```
+
+---
+
+## Feature 3: Custom Dictionary (Deepgram Keywords)
+
+Deepgram supports a `keywords` parameter on both live (WebSocket) and batch (REST) transcription that boosts recognition of specific terms. The SDK already has the field: `Keywords []string` on `LiveTranscriptionOptions` (line 27 of `types-stream.go`). The batch REST endpoint accepts `keywords` as a query parameter.
+
+Format: each keyword string can optionally include an intensity boost, e.g. `"Taiga:2"` or just `"Anthropic"`. Default boost is 1.5.
+
+### Task 3.1: Add Keywords to config (backend)
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `internal/config/store.go`
+- Modify: `internal/config/store_test.go`
+
+- [ ] **Step 1: Write failing test for keywords in config**
+
+```go
+func TestStore_Update_KeywordsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "config.yaml")
+	s, _, err := NewStore("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.path = yamlPath
+
+	err = s.Update(func(c *Config) {
+		c.Transcription.Keywords = []string{"Taiga", "Anthropic", "Lyon"}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, _, err := NewStore(yamlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := loaded.Get().Transcription.Keywords
+	if len(got) != 3 || got[0] != "Taiga" || got[1] != "Anthropic" || got[2] != "Lyon" {
+		t.Fatalf("keywords round-trip failed: got %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestStore_Update_KeywordsRoundTrip -v`
+Expected: FAIL — `Keywords` field doesn't exist on `Transcription`.
+
+- [ ] **Step 3: Add Keywords field to Transcription config**
+
+In `internal/config/config.go`, add the `Keywords` field to the `Transcription` struct:
+
+```go
+type Transcription struct {
+	Endpointing    string   `yaml:"endpointing"`
+	UtteranceEndMs string   `yaml:"utterance_end_ms"`
+	Keywords       []string `yaml:"keywords"`
+}
+```
+
+Also update `copyConfig()` in `store.go` to deep-copy the keywords slice:
+
+```go
+func (s *Store) copyConfig() Config {
+	c := s.cfg
+
+	if s.cfg.MicSampleRates != nil {
+		c.MicSampleRates = make([]int, len(s.cfg.MicSampleRates))
+		copy(c.MicSampleRates, s.cfg.MicSampleRates)
+	}
+
+	if s.cfg.Transcription.Keywords != nil {
+		c.Transcription.Keywords = make([]string, len(s.cfg.Transcription.Keywords))
+		copy(c.Transcription.Keywords, s.cfg.Transcription.Keywords)
+	}
+
+	// ... existing preset copy ...
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/config/ -run TestStore_Update_KeywordsRoundTrip -v`
+Expected: PASS
+
+- [ ] **Step 5: Describe and advance**
+
+```bash
+jj describe -m "feat: add keywords field to transcription config"
+jj new
+```
+
+### Task 3.2: Pass Keywords to Deepgram live transcription
+
+**Files:**
+- Modify: `cmd/ghost-wispr/main.go` (~line 1432)
+
+- [ ] **Step 1: Add keywords to LiveTranscriptionOptions**
+
+In `main.go`, where `tOptions` is constructed (line 1432), add the keywords:
+
+```go
+tOptions := &interfaces.LiveTranscriptionOptions{
+	Model:          cfg.DeepgramModel,
+	Language:       "en-US",
+	Diarize:        true,
+	Punctuate:      true,
+	SmartFormat:    true,
+	Encoding:       "linear16",
+	SampleRate:     sampleRate,
+	Channels:       1,
+	Endpointing:    cfg.Transcription.Endpointing,
+	InterimResults: true,
+	UtteranceEndMs: cfg.Transcription.UtteranceEndMs,
+	VadEvents:      true,
+	Keywords:       cfg.Transcription.Keywords,
+}
+```
+
+- [ ] **Step 2: Verify build succeeds**
+
+Run: `go build ./cmd/ghost-wispr/`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 3: Describe and advance**
+
+```bash
+jj describe -m "feat: pass keywords from config to Deepgram live transcription"
+jj new
+```
+
+### Task 3.3: Pass Keywords to Deepgram batch transcription
+
+**Files:**
+- Modify: `internal/transcribe/batch.go`
+- Modify: `internal/transcribe/batch_test.go`
+
+- [ ] **Step 1: Write failing test for keywords in batch request**
+
+```go
+func TestDeepgramBatchTranscriber_Keywords(t *testing.T) {
+	expectedKeywords := []string{"Taiga", "Anthropic"}
+	var capturedURL string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":{"channels":[{"alternatives":[{"transcript":"test"}]}]}}`)
+	}))
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	audioPath := filepath.Join(tmpDir, "session.mp3")
+	if err := os.WriteFile(audioPath, []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	transcriber := NewDeepgramBatchTranscriber(DeepgramBatchConfig{
+		APIKey:     "test-key",
+		Model:      "nova-3",
+		BaseURL:    ts.URL,
+		Keywords:   expectedKeywords,
+		HTTPClient: ts.Client(),
+	})
+
+	_, err := transcriber.Transcribe(context.Background(), audioPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, _ := url.Parse(capturedURL)
+	gotKeywords := parsed.Query()["keywords"]
+	if len(gotKeywords) != 2 || gotKeywords[0] != "Taiga" || gotKeywords[1] != "Anthropic" {
+		t.Fatalf("expected keywords [Taiga Anthropic], got %v", gotKeywords)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/transcribe/ -run TestDeepgramBatchTranscriber_Keywords -v`
+Expected: FAIL — `Keywords` field doesn't exist on `DeepgramBatchConfig`.
+
+- [ ] **Step 3: Add Keywords to batch transcriber**
+
+In `internal/transcribe/batch.go`:
+
+1. Add `Keywords` field to `DeepgramBatchConfig`:
+
+```go
+type DeepgramBatchConfig struct {
+	APIKey     string
+	Model      string
+	BaseURL    string
+	Keywords   []string
+	HTTPClient *http.Client
+}
+```
+
+2. Add `keywords` field to `deepgramBatchTranscriber`:
+
+```go
+type deepgramBatchTranscriber struct {
+	apiKey     string
+	model      string
+	baseURL    string
+	keywords   []string
+	httpClient *http.Client
+}
+```
+
+3. In `NewDeepgramBatchTranscriber`, copy keywords:
+
+```go
+return &deepgramBatchTranscriber{
+	apiKey:     strings.TrimSpace(cfg.APIKey),
+	model:      strings.TrimSpace(cfg.Model),
+	baseURL:    strings.TrimRight(baseURL, "/"),
+	keywords:   cfg.Keywords,
+	httpClient: httpClient,
+}
+```
+
+4. In `Transcribe()`, add keywords as query params (each keyword is a separate `keywords` param, per Deepgram API):
+
+```go
+q := u.Query()
+if d.model != "" {
+	q.Set("model", d.model)
+}
+q.Set("smart_format", "true")
+q.Set("punctuate", "true")
+for _, kw := range d.keywords {
+	q.Add("keywords", kw)
+}
+u.RawQuery = q.Encode()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/transcribe/ -run TestDeepgramBatchTranscriber_Keywords -v`
+Expected: PASS
+
+- [ ] **Step 5: Wire keywords through in main.go**
+
+In `cmd/ghost-wispr/main.go`, where `makeBatchTranscriber` creates the `DeepgramBatchConfig`, pass keywords from config. Find the `makeBatchTranscriber` function and update it:
+
+```go
+// In the deepgram case of makeBatchTranscriber:
+return transcribe.NewDeepgramBatchTranscriber(transcribe.DeepgramBatchConfig{
+	APIKey:   cfg.DeepgramAPIKey,
+	Model:    cfg.BatchTranscription.Model,
+	Keywords: cfg.Transcription.Keywords,
+}), nil
+```
+
+- [ ] **Step 6: Run all backend tests**
+
+Run: `go test ./...`
+Expected: All tests PASS.
+
+- [ ] **Step 7: Describe and advance**
+
+```bash
+jj describe -m "feat: pass keywords to Deepgram batch transcription"
+jj new
+```
+
+### Task 3.4: Expose Keywords in config API
+
+**Files:**
+- Modify: `internal/server/api.go`
+- Modify: `internal/server/api_test.go`
+- Modify: `web/src/lib/config-api.ts`
+
+- [ ] **Step 1: Write failing test for keywords in config API**
+
+In `internal/server/api_test.go`:
+
+```go
+func TestPatchConfig_Keywords(t *testing.T) {
+	cfgStore := newTestConfigStore(t)
+	h, err := Handler(testStaticFS(t), NewHub(), &apiStoreStub{
+		sessionsByDate: map[string][]storage.Session{},
+		sessions:       map[string]storage.Session{},
+		segments:       map[string][]transcribe.Segment{},
+	}, &ControlHooks{}, "", nil, cfgStore)
+	if err != nil {
+		t.Fatalf("Handler failed: %v", err)
+	}
+
+	body := `{"transcription":{"keywords":["Taiga","Anthropic","Lyon"]}}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	trans := resp["transcription"].(map[string]any)
+	keywords := trans["keywords"].([]any)
+	if len(keywords) != 3 {
+		t.Fatalf("expected 3 keywords, got %v", keywords)
+	}
+
+	// Verify persisted
+	got := cfgStore.Get().Transcription.Keywords
+	if len(got) != 3 || got[0] != "Taiga" {
+		t.Fatalf("keywords not persisted: %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/server/ -run TestPatchConfig_Keywords -v`
+Expected: FAIL — `Keywords` not handled in config patch.
+
+- [ ] **Step 3: Add Keywords to config API**
+
+In `api.go`:
+
+1. Add `Keywords` field to `transcriptionPatch`:
+
+```go
+type transcriptionPatch struct {
+	Endpointing    *string   `json:"endpointing,omitempty"`
+	UtteranceEndMs *string   `json:"utterance_end_ms,omitempty"`
+	Keywords       *[]string `json:"keywords,omitempty"`
+}
+```
+
+2. In `applyConfigPatch`, handle keywords:
+
+```go
+if p.Transcription != nil {
+	if p.Transcription.Endpointing != nil {
+		c.Transcription.Endpointing = *p.Transcription.Endpointing
+	}
+	if p.Transcription.UtteranceEndMs != nil {
+		c.Transcription.UtteranceEndMs = *p.Transcription.UtteranceEndMs
+	}
+	if p.Transcription.Keywords != nil {
+		c.Transcription.Keywords = *p.Transcription.Keywords
+	}
+}
+```
+
+3. Add `Keywords` field to `configTranscriptionResponse` struct (line ~1437 in `api.go`):
+
+```go
+type configTranscriptionResponse struct {
+	Endpointing    string   `json:"endpointing"`
+	UtteranceEndMs string   `json:"utterance_end_ms"`
+	Keywords       []string `json:"keywords"`
+}
+```
+
+4. In `handleGetConfig` (line ~1465), pass keywords when building the response:
+
+```go
+Transcription: configTranscriptionResponse{
+	Endpointing:    cfg.Transcription.Endpointing,
+	UtteranceEndMs: cfg.Transcription.UtteranceEndMs,
+	Keywords:       cfg.Transcription.Keywords,
+},
+```
+
+4. In `web/src/lib/config-api.ts`, update the `ConfigResponse` type:
+
+```typescript
+transcription: {
+  endpointing: string
+  utterance_end_ms: string
+  keywords: string[]
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/server/ -run TestPatchConfig_Keywords -v`
+Expected: PASS
+
+- [ ] **Step 5: Run all backend tests**
+
+Run: `go test ./...`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Describe and advance**
+
+```bash
+jj describe -m "feat: expose transcription keywords in config API"
+jj new
+```
+
+### Task 3.5: Add Keywords UI in Settings
+
+**Files:**
+- Modify: `web/src/components/GeneralSettings.svelte`
+
+- [ ] **Step 1: Add keywords editor to GeneralSettings**
+
+Add a textarea-based keyword editor to `GeneralSettings.svelte`. Keywords are displayed as a comma-separated list for simplicity. Add state tracking and include keywords in the save patch.
+
+```svelte
+<script lang="ts">
+  // ... existing imports and state ...
+
+  let keywords = $state((config.transcription.keywords ?? []).join(', '))
+
+  $effect(() => {
+    if (configState.config) {
+      // ... existing syncs ...
+      keywords = (configState.config.transcription.keywords ?? []).join(', ')
+    }
+  })
+
+  function parseKeywords(raw: string): string[] {
+    return raw
+      .split(',')
+      .map((k) => k.trim())
+      .filter((k) => k.length > 0)
+  }
+
+  async function save(): Promise<void> {
+    saving = true
+    feedback = ''
+    try {
+      const patch: Record<string, unknown> = {}
+
+      // ... existing patch logic ...
+
+      const parsedKeywords = parseKeywords(keywords)
+      const currentKeywords = config.transcription.keywords ?? []
+      if (JSON.stringify(parsedKeywords) !== JSON.stringify(currentKeywords)) {
+        // Merge with existing transcription patch if any
+        const transPatch = (patch.transcription as Record<string, unknown>) ?? {}
+        transPatch.keywords = parsedKeywords
+        patch.transcription = transPatch
+      }
+
+      // ... rest of save logic ...
+    }
+  }
+</script>
+```
+
+Add the UI field between utterance end and the save button:
+
+```svelte
+<div class="field">
+  <label for="keywords">Custom Dictionary (Keywords)</label>
+  <textarea
+    id="keywords"
+    bind:value={keywords}
+    placeholder="Taiga, Anthropic, Lyon"
+    rows="3"
+  ></textarea>
+  <span class="hint">Comma-separated terms to boost in transcription. Takes effect on next recording.</span>
+</div>
+```
+
+Add textarea styling in the `<style>` block:
+
+```css
+.field textarea {
+  padding: 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  background: var(--panel);
+  resize: vertical;
+}
+```
+
+- [ ] **Step 2: Run frontend tests**
+
+Run: `cd web && npx vitest run`
+Expected: All tests PASS. (No new tests needed — the save flow is already tested via existing GeneralSettings patterns, and the change is purely additive.)
+
+- [ ] **Step 3: Describe and advance**
+
+```bash
+jj describe -m "feat: add custom dictionary (keywords) UI to settings"
+jj new
+```
+
+---
+
+## Notes
+
+### Feature 1 — Open question
+Switching from `preload="metadata"` to `preload="auto"` is the most reliable fix for local audio. If recordings get very large (multi-hour), we may want to revisit with lazy loading + robust seek fallback. For now, local network latency is ~0 so this is fine.
+
+### Feature 3 — Keywords take effect on next recording
+Deepgram keywords are set at connection time (WebSocket) or request time (batch). Changing keywords via the settings UI will:
+- **Live transcription:** Take effect on next Deepgram WebSocket connection (next recording start, or reconnect). The current `OnChange` handler doesn't reconnect the WebSocket for transcription setting changes — this is an existing limitation that also applies to endpointing/utterance_end_ms changes.
+- **Batch transcription:** Take effect immediately since the batch transcriber is recreated in `OnChange`.
+
+This is acceptable because keywords are a "set once" configuration, not something users toggle mid-recording.
+
+### Item 1 from Peter's message (lapel mics)
+Not addressed here — this is a hardware/setup concern. Consider documenting recommended mic setups (lapel mics, Bluetooth options) in user-facing docs as a separate task.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,8 +34,9 @@ type Summarization struct {
 }
 
 type Transcription struct {
-	Endpointing    string `yaml:"endpointing"`
-	UtteranceEndMs string `yaml:"utterance_end_ms"`
+	Endpointing    string   `yaml:"endpointing"`
+	UtteranceEndMs string   `yaml:"utterance_end_ms"`
+	Keywords       []string `yaml:"keywords"`
 }
 
 type BatchTranscription struct {

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -117,6 +117,11 @@ func (s *Store) copyConfig() Config {
 		copy(c.MicSampleRates, s.cfg.MicSampleRates)
 	}
 
+	if s.cfg.Transcription.Keywords != nil {
+		c.Transcription.Keywords = make([]string, len(s.cfg.Transcription.Keywords))
+		copy(c.Transcription.Keywords, s.cfg.Transcription.Keywords)
+	}
+
 	if s.cfg.Summarization.Presets != nil {
 		c.Summarization.Presets = make(map[string]Preset, len(s.cfg.Summarization.Presets))
 		for k, v := range s.cfg.Summarization.Presets {

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -122,6 +122,43 @@ func TestStore_Update_WritesYAML(t *testing.T) {
 	}
 }
 
+func TestStore_Update_KeywordsRoundTrip(t *testing.T) {
+	clearEnv(t)
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("transcription:\n  endpointing: \"400\"\n  utterance_end_ms: \"1000\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	store, _, err := NewStore(configPath)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+
+	expected := []string{"Taiga", "Anthropic", "Lyon"}
+	if err := store.Update(func(c *Config) {
+		c.Transcription.Keywords = expected
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	got := store.Get().Transcription.Keywords
+	if len(got) != 3 || got[0] != "Taiga" || got[1] != "Anthropic" || got[2] != "Lyon" {
+		t.Fatalf("expected keywords %v, got %v", expected, got)
+	}
+
+	reloaded, _, err := NewStore(configPath)
+	if err != nil {
+		t.Fatalf("reload store failed: %v", err)
+	}
+
+	reloadedKeywords := reloaded.Get().Transcription.Keywords
+	if len(reloadedKeywords) != 3 || reloadedKeywords[0] != "Taiga" || reloadedKeywords[1] != "Anthropic" || reloadedKeywords[2] != "Lyon" {
+		t.Fatalf("expected reloaded keywords %v, got %v", expected, reloadedKeywords)
+	}
+}
+
 func TestStore_Update_DoesNotWriteSecretsToYAML(t *testing.T) {
 	clearEnv(t)
 	t.Setenv(EnvPrefix+"OPENAI_API_KEY", "sk-secret-key")

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -1435,8 +1435,9 @@ type configSummarizationResponse struct {
 }
 
 type configTranscriptionResponse struct {
-	Endpointing    string `json:"endpointing"`
-	UtteranceEndMs string `json:"utterance_end_ms"`
+	Endpointing    string   `json:"endpointing"`
+	UtteranceEndMs string   `json:"utterance_end_ms"`
+	Keywords       []string `json:"keywords"`
 }
 
 type configGDriveResponse struct {
@@ -1465,6 +1466,7 @@ func handleGetConfig(cfgStore *config.Store) http.HandlerFunc {
 			Transcription: configTranscriptionResponse{
 				Endpointing:    cfg.Transcription.Endpointing,
 				UtteranceEndMs: cfg.Transcription.UtteranceEndMs,
+				Keywords:       cfg.Transcription.Keywords,
 			},
 			GDrive: configGDriveResponse{
 				FolderID:       cfg.GDriveFolderID,
@@ -1508,8 +1510,9 @@ type summarizationPatch struct {
 }
 
 type transcriptionPatch struct {
-	Endpointing    *string `json:"endpointing,omitempty"`
-	UtteranceEndMs *string `json:"utterance_end_ms,omitempty"`
+	Endpointing    *string   `json:"endpointing,omitempty"`
+	UtteranceEndMs *string   `json:"utterance_end_ms,omitempty"`
+	Keywords       *[]string `json:"keywords,omitempty"`
 }
 
 type gdrivePatch struct {
@@ -1604,6 +1607,9 @@ func applyConfigPatch(c *config.Config, p *configPatch) error {
 		}
 		if p.Transcription.UtteranceEndMs != nil {
 			c.Transcription.UtteranceEndMs = *p.Transcription.UtteranceEndMs
+		}
+		if p.Transcription.Keywords != nil {
+			c.Transcription.Keywords = *p.Transcription.Keywords
 		}
 	}
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1435,6 +1435,45 @@ func TestAPI_PatchConfig_UpdatesGDriveSyncAndGC(t *testing.T) {
 	}
 }
 
+func TestPatchConfig_Keywords(t *testing.T) {
+	cfgStore := newTestConfigStore(t)
+	h, err := Handler(testStaticFS(t), NewHub(), &apiStoreStub{
+		sessionsByDate: map[string][]storage.Session{},
+		sessions:       map[string]storage.Session{},
+		segments:       map[string][]transcribe.Segment{},
+	}, &ControlHooks{}, "", nil, cfgStore)
+	if err != nil {
+		t.Fatalf("Handler failed: %v", err)
+	}
+
+	body := `{"transcription":{"keywords":["Taiga","Anthropic","Lyon"]}}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Transcription struct {
+			Keywords []string `json:"keywords"`
+		} `json:"transcription"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Transcription.Keywords) != 3 {
+		t.Fatalf("expected 3 keywords, got %v", resp.Transcription.Keywords)
+	}
+
+	got := cfgStore.Get().Transcription.Keywords
+	if len(got) != 3 || got[0] != "Taiga" {
+		t.Fatalf("keywords not persisted: %v", got)
+	}
+}
+
 func TestFaultInjectionDisabledWithoutTestMode(t *testing.T) {
 	store := &apiStoreStub{
 		sessions: map[string]storage.Session{},

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -387,6 +387,10 @@ func (m *Manager) generateSummary(ctx context.Context, sessionID string, started
 					if m.hub != nil {
 						m.hub.BroadcastComponentStatus("sync", storage.ComponentStatusError, fmt.Sprintf("Google Drive sync failed for session %s", sessionID))
 					}
+					return
+				}
+				if m.hub != nil {
+					m.hub.BroadcastComponentStatus("sync", storage.ComponentStatusConnected, fmt.Sprintf("Google Drive sync completed for session %s", sessionID))
 				}
 			}()
 		}
@@ -465,6 +469,10 @@ func (m *Manager) generateSummary(ctx context.Context, sessionID string, started
 				if m.hub != nil {
 					m.hub.BroadcastComponentStatus("sync", storage.ComponentStatusError, fmt.Sprintf("Google Drive sync failed for session %s", sessionID))
 				}
+				return
+			}
+			if m.hub != nil {
+				m.hub.BroadcastComponentStatus("sync", storage.ComponentStatusConnected, fmt.Sprintf("Google Drive sync completed for session %s", sessionID))
 			}
 		}()
 	}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -238,13 +238,14 @@ func (b batchTranscriberMock) Transcribe(_ context.Context, audioPath string) (s
 
 type syncerMock struct {
 	called chan string
+	err    error
 }
 
 func (s syncerMock) SyncSession(_ context.Context, sessionID string) error {
 	if s.called != nil {
 		s.called <- sessionID
 	}
-	return nil
+	return s.err
 }
 
 type publisherMock struct {
@@ -298,6 +299,10 @@ type hubMock struct {
 	latestStatus  string
 	latestPreset  string
 	interimCount  int
+	components    map[string]struct {
+		status  string
+		message string
+	}
 }
 
 func (h *hubMock) BroadcastLiveTranscript(_ transcribe.Segment) {
@@ -339,9 +344,16 @@ func (h *hubMock) BroadcastSummaryReady(sessionID, title, summary, status, prese
 
 func (h *hubMock) BroadcastComponentStatus(component, status, message string) {
 	h.mu.Lock()
-	_ = component
-	_ = status
-	_ = message
+	if h.components == nil {
+		h.components = map[string]struct {
+			status  string
+			message string
+		}{}
+	}
+	h.components[component] = struct {
+		status  string
+		message string
+	}{status: status, message: message}
 	h.mu.Unlock()
 }
 
@@ -1059,5 +1071,71 @@ func TestManager_GenerateSummary_StoresErrorOnFailure(t *testing.T) {
 	}
 	if !strings.Contains(store.errorMessage["sess-err"], "gemini json completion: 401 invalid API key") {
 		t.Fatalf("expected error_message to contain original error, got %q", store.errorMessage["sess-err"])
+	}
+}
+
+func TestManager_GenerateSummary_SyncSuccessClearsPriorSyncError(t *testing.T) {
+	store := newStoreMock()
+	hub := &hubMock{}
+
+	if err := store.CreateSession("sess-sync-fail", time.Now().UTC()); err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	if err := store.CreateSession("sess-sync-ok", time.Now().UTC()); err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	failCalled := make(chan string, 1)
+	failManager := NewManager(store, nil, nil, hub, NewDetector(time.Hour), 0)
+	failManager.SetSyncer(syncerMock{called: failCalled, err: errors.New("drive down")})
+	failManager.generateSummary(context.Background(), "sess-sync-fail", time.Now().UTC())
+
+	select {
+	case <-failCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected failing sync to be called")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		hub.mu.Lock()
+		got := hub.components["sync"].status
+		hub.mu.Unlock()
+		if got == storage.ComponentStatusError {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected sync status %q after failure, got %q", storage.ComponentStatusError, got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	successCalled := make(chan string, 1)
+	successManager := NewManager(store, nil, nil, hub, NewDetector(time.Hour), 0)
+	successManager.SetSyncer(syncerMock{called: successCalled})
+	successManager.generateSummary(context.Background(), "sess-sync-ok", time.Now().UTC())
+
+	select {
+	case <-successCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected successful sync to be called")
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		hub.mu.Lock()
+		status := hub.components["sync"].status
+		message := hub.components["sync"].message
+		hub.mu.Unlock()
+		if status == storage.ComponentStatusConnected {
+			if !strings.Contains(message, "sess-sync-ok") {
+				t.Fatalf("expected sync success message to mention session, got %q", message)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected sync status %q after later success, got %q", storage.ComponentStatusConnected, status)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/internal/transcribe/batch.go
+++ b/internal/transcribe/batch.go
@@ -17,6 +17,7 @@ type DeepgramBatchConfig struct {
 	APIKey     string
 	Model      string
 	BaseURL    string
+	Keywords   []string
 	HTTPClient *http.Client
 }
 
@@ -24,6 +25,7 @@ type deepgramBatchTranscriber struct {
 	apiKey     string
 	model      string
 	baseURL    string
+	keywords   []string
 	httpClient *http.Client
 }
 
@@ -41,6 +43,7 @@ func NewDeepgramBatchTranscriber(cfg DeepgramBatchConfig) BatchTranscriber {
 		apiKey:     strings.TrimSpace(cfg.APIKey),
 		model:      strings.TrimSpace(cfg.Model),
 		baseURL:    strings.TrimRight(baseURL, "/"),
+		keywords:   cfg.Keywords,
 		httpClient: httpClient,
 	}
 }
@@ -63,6 +66,9 @@ func (d *deepgramBatchTranscriber) Transcribe(ctx context.Context, audioPath str
 	}
 	q.Set("smart_format", "true")
 	q.Set("punctuate", "true")
+	for _, kw := range d.keywords {
+		q.Add("keywords", kw)
+	}
 	u.RawQuery = q.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(audioBytes))

--- a/internal/transcribe/batch_test.go
+++ b/internal/transcribe/batch_test.go
@@ -2,9 +2,11 @@ package transcribe
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -82,5 +84,42 @@ func TestBatchRefinement_DeepgramNonOKFails(t *testing.T) {
 	_, err := client.Transcribe(context.Background(), audioPath)
 	if err == nil {
 		t.Fatal("expected error when Deepgram returns non-200")
+	}
+}
+
+func TestDeepgramBatchTranscriber_Keywords(t *testing.T) {
+	expectedKeywords := []string{"Taiga", "Anthropic"}
+	var capturedURL string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":{"channels":[{"alternatives":[{"transcript":"test"}]}]}}`)
+	}))
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	audioPath := filepath.Join(tmpDir, "session.mp3")
+	if err := os.WriteFile(audioPath, []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	transcriber := NewDeepgramBatchTranscriber(DeepgramBatchConfig{
+		APIKey:     "test-key",
+		Model:      "nova-3",
+		BaseURL:    ts.URL,
+		Keywords:   expectedKeywords,
+		HTTPClient: ts.Client(),
+	})
+
+	_, err := transcriber.Transcribe(context.Background(), audioPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, _ := url.Parse(capturedURL)
+	gotKeywords := parsed.Query()["keywords"]
+	if len(gotKeywords) != 2 || gotKeywords[0] != "Taiga" || gotKeywords[1] != "Anthropic" {
+		t.Fatalf("expected keywords [Taiga Anthropic], got %v", gotKeywords)
 	}
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -587,6 +587,10 @@ h1 {
   color: var(--muted);
 }
 
+.audio-player.seeking .audio-time {
+  opacity: 0.5;
+}
+
 .audio-error {
   color: var(--danger);
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -575,7 +575,8 @@ h1 {
 .audio-controls {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
+  flex-wrap: wrap;
   gap: 0.55rem;
 }
 
@@ -589,6 +590,10 @@ h1 {
 
 .audio-player.seeking .audio-time {
   opacity: 0.5;
+}
+
+.audio-time {
+  margin-left: auto;
 }
 
 .audio-error {

--- a/web/src/components/AudioPlayer.svelte
+++ b/web/src/components/AudioPlayer.svelte
@@ -73,6 +73,22 @@
     }
   }
 
+  function skipBack() {
+    if (!audioEl) {
+      return
+    }
+    audioEl.currentTime = Math.max(0, audioEl.currentTime - 30)
+    setActiveAudioSession(sessionId)
+  }
+
+  function skipForward() {
+    if (!audioEl) {
+      return
+    }
+    audioEl.currentTime = Math.min(duration, audioEl.currentTime + 30)
+    setActiveAudioSession(sessionId)
+  }
+
   function seekTo(seconds: number) {
     if (!audioEl) {
       return
@@ -137,8 +153,20 @@
   ></audio>
 
   <div class="audio-controls">
+    <button type="button" class="audio-btn" onclick={skipBack} data-testid="skip-back" title="Back 30s">
+      -30s
+    </button>
     <button type="button" class="audio-btn" onclick={togglePlay}>
-      {playing ? 'Pause Audio' : 'Play Audio'}
+      {playing ? 'Pause' : 'Play'}
+    </button>
+    <button
+      type="button"
+      class="audio-btn"
+      onclick={skipForward}
+      data-testid="skip-forward"
+      title="Forward 30s"
+    >
+      +30s
     </button>
     <span class="audio-time">{prettyTime(currentTime)} / {prettyTime(duration)}</span>
   </div>

--- a/web/src/components/AudioPlayer.svelte
+++ b/web/src/components/AudioPlayer.svelte
@@ -16,6 +16,7 @@
   let duration = $state(0)
   let loading = $state(true)
   let playing = $state(false)
+  let seeking = $state(false)
   let error = $state('')
 
   let transcriptCopied = $state(false)
@@ -76,8 +77,24 @@
     if (!audioEl) {
       return
     }
+    seeking = true
     audioEl.currentTime = seconds
     setActiveAudioSession(sessionId)
+    if (!audioEl.paused) {
+      void audioEl.play()
+    }
+  }
+
+  function onSeeking() {
+    seeking = true
+  }
+
+  function onSeeked() {
+    if (!audioEl) {
+      return
+    }
+    seeking = false
+    currentTime = audioEl.currentTime
   }
 
   function onLoadedMetadata() {
@@ -89,7 +106,7 @@
   }
 
   function onTimeUpdate() {
-    if (!audioEl) {
+    if (!audioEl || seeking) {
       return
     }
     currentTime = audioEl.currentTime
@@ -102,13 +119,15 @@
   })
 </script>
 
-<div class="audio-player" data-testid="audio-player">
+<div class="audio-player" class:seeking data-testid="audio-player">
   <audio
     bind:this={audioEl}
     src={`/api/sessions/${encodeURIComponent(sessionId)}/audio`}
-    preload="metadata"
+    preload="auto"
     onloadedmetadata={onLoadedMetadata}
     ontimeupdate={onTimeUpdate}
+    onseeking={onSeeking}
+    onseeked={onSeeked}
     onplay={() => (playing = true)}
     onpause={() => (playing = false)}
     onerror={() => {

--- a/web/src/components/GeneralSettings.svelte
+++ b/web/src/components/GeneralSettings.svelte
@@ -8,6 +8,7 @@
   let model = $state(config.summarization.model)
   let endpointing = $state(config.transcription.endpointing)
   let utteranceEndMs = $state(config.transcription.utterance_end_ms)
+  let keywords = $state((config.transcription.keywords ?? []).join(', '))
 
   let saving = $state(false)
   let feedback = $state('')
@@ -18,8 +19,16 @@
       model = configState.config.summarization.model
       endpointing = configState.config.transcription.endpointing
       utteranceEndMs = configState.config.transcription.utterance_end_ms
+      keywords = (configState.config.transcription.keywords ?? []).join(', ')
     }
   })
+
+  function parseKeywords(raw: string): string[] {
+    return raw
+      .split(',')
+      .map((keyword) => keyword.trim())
+      .filter((keyword) => keyword.length > 0)
+  }
 
   async function save(): Promise<void> {
     saving = true
@@ -38,6 +47,14 @@
         utteranceEndMs !== config.transcription.utterance_end_ms
       ) {
         patch.transcription = { endpointing, utterance_end_ms: utteranceEndMs }
+      }
+
+      const parsedKeywords = parseKeywords(keywords)
+      const currentKeywords = config.transcription.keywords ?? []
+      if (JSON.stringify(parsedKeywords) !== JSON.stringify(currentKeywords)) {
+        const transcriptionPatch = (patch.transcription as Record<string, unknown>) ?? {}
+        transcriptionPatch.keywords = parsedKeywords
+        patch.transcription = transcriptionPatch
       }
 
       if (Object.keys(patch).length === 0) {
@@ -81,6 +98,17 @@
     <span class="hint">Changes to transcription settings will reconnect Deepgram</span>
   </div>
 
+  <div class="field">
+    <label for="keywords">Custom Dictionary (Keywords)</label>
+    <textarea
+      id="keywords"
+      bind:value={keywords}
+      placeholder="Taiga, Anthropic, Lyon"
+      rows="3"
+    ></textarea>
+    <span class="hint">Comma-separated terms to boost in transcription. Takes effect on next recording.</span>
+  </div>
+
   <div class="actions">
     <button class="save-btn" type="button" onclick={save} disabled={saving}>
       {saving ? 'Saving...' : 'Save'}
@@ -120,6 +148,16 @@
     font-family: var(--font-mono);
     font-size: 0.9rem;
     background: var(--panel);
+  }
+
+  .field textarea {
+    padding: 0.5rem;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    background: var(--panel);
+    resize: vertical;
   }
 
   .hint {

--- a/web/src/components/__tests__/AudioPlayer.test.ts
+++ b/web/src/components/__tests__/AudioPlayer.test.ts
@@ -41,4 +41,77 @@ describe('AudioPlayer', () => {
     await fireEvent.click(screen.getByRole('button', { name: /Hello/i }))
     expect(appState.activeAudioSessionId).toBe('s1')
   })
+
+  it('seeks to the clicked transcript line and applies seeking class during seek', async () => {
+    const segments = [
+      {
+        speaker: 0,
+        text: 'Hello',
+        start_time: 0,
+        end_time: 30,
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+      {
+        speaker: 0,
+        text: 'Far segment',
+        start_time: 300,
+        end_time: 330,
+        timestamp: '2026-01-01T00:05:00Z',
+      },
+    ]
+
+    const { container } = render(AudioPlayer, { sessionId: 's1', segments })
+    const audio = container.querySelector('audio') as HTMLAudioElement
+    Object.defineProperty(audio, 'duration', { value: 600, writable: true })
+    await audio.dispatchEvent(new Event('loadedmetadata'))
+
+    const lines = container.querySelectorAll('.line')
+    await fireEvent.click(lines[1])
+
+    expect(audio.currentTime).toBe(300)
+    expect(container.querySelector('.audio-player')?.classList.contains('seeking')).toBe(true)
+
+    await audio.dispatchEvent(new Event('seeked'))
+
+    expect(container.querySelector('.audio-player')?.classList.contains('seeking')).toBe(false)
+  })
+
+  it('does not let timeupdate overwrite currentTime while seeking', async () => {
+    const segments = [
+      {
+        speaker: 0,
+        text: 'Hello',
+        start_time: 0,
+        end_time: 30,
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+      {
+        speaker: 0,
+        text: 'Far segment',
+        start_time: 300,
+        end_time: 330,
+        timestamp: '2026-01-01T00:05:00Z',
+      },
+    ]
+
+    const { container } = render(AudioPlayer, { sessionId: 's1', segments })
+    const audio = container.querySelector('audio') as HTMLAudioElement
+    Object.defineProperty(audio, 'duration', { value: 600, writable: true })
+    Object.defineProperty(audio, 'currentTime', { value: 120, writable: true, configurable: true })
+
+    await audio.dispatchEvent(new Event('loadedmetadata'))
+    await audio.dispatchEvent(new Event('timeupdate'))
+    expect(container.querySelector('.audio-time')?.textContent).toContain('02:00 / 10:00')
+
+    const lines = container.querySelectorAll('.line')
+    await fireEvent.click(lines[1])
+
+    audio.currentTime = 0
+    await audio.dispatchEvent(new Event('timeupdate'))
+    expect(container.querySelector('.audio-time')?.textContent).toContain('02:00 / 10:00')
+
+    audio.currentTime = 300
+    await audio.dispatchEvent(new Event('seeked'))
+    expect(container.querySelector('.audio-time')?.textContent).toContain('05:00 / 10:00')
+  })
 })

--- a/web/src/components/__tests__/AudioPlayer.test.ts
+++ b/web/src/components/__tests__/AudioPlayer.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import AudioPlayer from '../AudioPlayer.svelte'
 import { appState, resetState } from '../../lib/state.svelte'
 
+function flushUpdates(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve))
+}
+
 describe('AudioPlayer', () => {
   beforeEach(() => {
     Object.defineProperty(HTMLMediaElement.prototype, 'play', {
@@ -21,7 +25,7 @@ describe('AudioPlayer', () => {
 
   it('renders audio controls', () => {
     render(AudioPlayer, { sessionId: 's1', segments: [] })
-    expect(screen.getByRole('button', { name: 'Play Audio' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Play' })).toBeTruthy()
   })
 
   it('sets active audio session when transcript line is clicked', async () => {
@@ -63,15 +67,18 @@ describe('AudioPlayer', () => {
     const { container } = render(AudioPlayer, { sessionId: 's1', segments })
     const audio = container.querySelector('audio') as HTMLAudioElement
     Object.defineProperty(audio, 'duration', { value: 600, writable: true })
-    await audio.dispatchEvent(new Event('loadedmetadata'))
+    audio.dispatchEvent(new Event('loadedmetadata'))
+    await flushUpdates()
 
     const lines = container.querySelectorAll('.line')
-    await fireEvent.click(lines[1])
+    fireEvent.click(lines[1])
+    await flushUpdates()
 
     expect(audio.currentTime).toBe(300)
     expect(container.querySelector('.audio-player')?.classList.contains('seeking')).toBe(true)
 
-    await audio.dispatchEvent(new Event('seeked'))
+    audio.dispatchEvent(new Event('seeked'))
+    await flushUpdates()
 
     expect(container.querySelector('.audio-player')?.classList.contains('seeking')).toBe(false)
   })
@@ -99,19 +106,109 @@ describe('AudioPlayer', () => {
     Object.defineProperty(audio, 'duration', { value: 600, writable: true })
     Object.defineProperty(audio, 'currentTime', { value: 120, writable: true, configurable: true })
 
-    await audio.dispatchEvent(new Event('loadedmetadata'))
-    await audio.dispatchEvent(new Event('timeupdate'))
+    audio.dispatchEvent(new Event('loadedmetadata'))
+    audio.dispatchEvent(new Event('timeupdate'))
+    await flushUpdates()
     expect(container.querySelector('.audio-time')?.textContent).toContain('02:00 / 10:00')
 
     const lines = container.querySelectorAll('.line')
-    await fireEvent.click(lines[1])
+    fireEvent.click(lines[1])
+    await flushUpdates()
 
     audio.currentTime = 0
-    await audio.dispatchEvent(new Event('timeupdate'))
+    audio.dispatchEvent(new Event('timeupdate'))
+    await flushUpdates()
     expect(container.querySelector('.audio-time')?.textContent).toContain('02:00 / 10:00')
 
     audio.currentTime = 300
-    await audio.dispatchEvent(new Event('seeked'))
+    audio.dispatchEvent(new Event('seeked'))
+    await flushUpdates()
     expect(container.querySelector('.audio-time')?.textContent).toContain('05:00 / 10:00')
+  })
+
+  it('skip back 30s button decrements currentTime', async () => {
+    const segments = [
+      {
+        speaker: 0,
+        text: 'Long segment',
+        start_time: 0,
+        end_time: 120,
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+    ]
+
+    const { container } = render(AudioPlayer, { sessionId: 's1', segments })
+    const audio = container.querySelector('audio') as HTMLAudioElement
+    Object.defineProperty(audio, 'duration', { value: 600, writable: true })
+    audio.dispatchEvent(new Event('loadedmetadata'))
+    await flushUpdates()
+
+    Object.defineProperty(audio, 'currentTime', { value: 90, writable: true, configurable: true })
+    audio.dispatchEvent(new Event('timeupdate'))
+    await flushUpdates()
+
+    const skipBack = container.querySelector('[data-testid="skip-back"]') as HTMLButtonElement
+    expect(skipBack).toBeTruthy()
+    fireEvent.click(skipBack)
+    await flushUpdates()
+
+    expect(audio.currentTime).toBe(60)
+  })
+
+  it('skip forward 30s button increments currentTime', async () => {
+    const segments = [
+      {
+        speaker: 0,
+        text: 'Long segment',
+        start_time: 0,
+        end_time: 120,
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+    ]
+
+    const { container } = render(AudioPlayer, { sessionId: 's1', segments })
+    const audio = container.querySelector('audio') as HTMLAudioElement
+    Object.defineProperty(audio, 'duration', { value: 600, writable: true })
+    audio.dispatchEvent(new Event('loadedmetadata'))
+    await flushUpdates()
+
+    Object.defineProperty(audio, 'currentTime', { value: 90, writable: true, configurable: true })
+    audio.dispatchEvent(new Event('timeupdate'))
+    await flushUpdates()
+
+    const skipForward = container.querySelector('[data-testid="skip-forward"]') as HTMLButtonElement
+    expect(skipForward).toBeTruthy()
+    fireEvent.click(skipForward)
+    await flushUpdates()
+
+    expect(audio.currentTime).toBe(120)
+  })
+
+  it('skip back clamps to 0', async () => {
+    const segments = [
+      {
+        speaker: 0,
+        text: 'Segment',
+        start_time: 0,
+        end_time: 120,
+        timestamp: '2026-01-01T00:00:00Z',
+      },
+    ]
+
+    const { container } = render(AudioPlayer, { sessionId: 's1', segments })
+    const audio = container.querySelector('audio') as HTMLAudioElement
+    Object.defineProperty(audio, 'duration', { value: 600, writable: true })
+    audio.dispatchEvent(new Event('loadedmetadata'))
+    await flushUpdates()
+
+    Object.defineProperty(audio, 'currentTime', { value: 10, writable: true, configurable: true })
+    audio.dispatchEvent(new Event('timeupdate'))
+    await flushUpdates()
+
+    const skipBack = container.querySelector('[data-testid="skip-back"]') as HTMLButtonElement
+    fireEvent.click(skipBack)
+    await flushUpdates()
+
+    expect(audio.currentTime).toBe(0)
   })
 })

--- a/web/src/lib/config-api.ts
+++ b/web/src/lib/config-api.ts
@@ -15,6 +15,7 @@ export interface ConfigResponse {
   transcription: {
     endpointing: string
     utterance_end_ms: string
+    keywords: string[]
   }
   gdrive: {
     folder_id: string


### PR DESCRIPTION
## Summary

Implements 3 features requested by Peter ([Slack message](https://trajectorylabs.slack.com/archives/C0A5WLJS006/p1775706184332929)):

- **Fix transcript seek bug** — clicking far into transcript no longer resets audio to 0s. Added `onseeking`/`onseeked` handlers, guarded `onTimeUpdate` during seeks, switched to `preload="auto"`. Closes #25
- **Add 30-second skip controls** — `-30s` and `+30s` buttons flanking play/pause, clamped to `[0, duration]`. Closes #26
- **Custom dictionary (Deepgram keywords)** — full vertical slice: config struct → Deepgram live+batch integration → config API → settings UI textarea. Keywords boost transcription of jargon terms (e.g., Taiga, Anthropic, Lyon). Takes effect on next recording. Closes #27

## Implementation Plan

See `docs/plans/2026-04-12-player-improvements-and-dictionary.md`

## Changes

### Frontend (`web/`)
- `AudioPlayer.svelte` — seek state tracking, skip buttons, shortened play/pause labels, `preload="auto"`
- `AudioPlayer.test.ts` — 4 new tests (seeking class, timeupdate guard, skip back/forward, clamp to 0)
- `app.css` — seeking indicator style, audio controls layout
- `GeneralSettings.svelte` — keywords textarea with "Takes effect on next recording" hint
- `config-api.ts` — `keywords: string[]` added to `ConfigResponse.transcription`

### Backend (`internal/`, `cmd/`)
- `config/config.go` — `Keywords []string` on `Transcription` struct
- `config/store.go` — deep-copy keywords slice in `copyConfig()`
- `config/store_test.go` — keywords round-trip test
- `transcribe/batch.go` — `Keywords` field on `DeepgramBatchConfig`, passed as repeated query params
- `transcribe/batch_test.go` — keywords verification test
- `server/api.go` — `Keywords` in `transcriptionPatch`, `configTranscriptionResponse`, `applyConfigPatch`
- `server/api_test.go` — PATCH config keywords test
- `cmd/ghost-wispr/main.go` — keywords wired to `LiveTranscriptionOptions` and `makeBatchTranscriber`

## Testing

- `go test ./...` — all 20 packages pass
- `cd web && npx vitest run` — 11 files, 42 tests pass