### PR TITLE
feat(web): show refined transcript in UI and copy

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -676,6 +676,63 @@ h1 {
   font-size: 0.8rem;
 }
 
+.transcript-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.transcript-toggle {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: 0.25rem;
+  overflow: hidden;
+}
+
+.toggle-btn {
+  font-size: 0.65rem;
+  font-weight: 500;
+  padding: 0.15rem 0.4rem;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.toggle-btn + .toggle-btn {
+  border-left: 1px solid var(--line);
+}
+
+.toggle-btn:hover {
+  color: var(--ink);
+}
+
+.toggle-btn.active {
+  background: var(--accent-soft);
+  color: var(--ink);
+}
+
+.refining-indicator {
+  font-size: 0.65rem;
+  font-style: italic;
+  color: var(--muted);
+}
+
+.transcript-refined {
+  margin-top: 0.35rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--line);
+  border-radius: 0.3rem;
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 0.85rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  max-height: 320px;
+  overflow: auto;
+}
+
 /* ── Summary markdown ── */
 
 .summary-markdown {

--- a/web/src/components/AudioPlayer.svelte
+++ b/web/src/components/AudioPlayer.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
   import { appState, setActiveAudioSession } from '../lib/state.svelte'
-  import type { Segment } from '../lib/types'
+  import { RefinementStatus, type Segment, type SessionSummary } from '../lib/types'
   import { copyText } from '../lib/clipboard'
 
   let {
     sessionId,
     segments,
+    session,
   }: {
     sessionId: string
     segments: Segment[]
+    session?: SessionSummary
   } = $props()
 
   let audioEl: HTMLAudioElement | null = null
@@ -20,10 +22,47 @@
 
   let transcriptCopied = $state(false)
 
-  async function copyTranscript() {
-    const text = segments
+  // Refined transcript: prefer the explicit refined_transcript, fall back to
+  // canonical_transcript when the source is 'refined' (covers historical sessions
+  // where the backend canonicalized into canonical_transcript).
+  const refinedText = $derived.by(() => {
+    if (!session) return ''
+    const refined = session.refined_transcript?.trim()
+    if (refined) return refined
+    if (session.transcript_source === 'refined') {
+      return session.canonical_transcript?.trim() ?? ''
+    }
+    return ''
+  })
+
+  const refinementCompleted = $derived(
+    session?.refinement_status === RefinementStatus.Completed && refinedText.length > 0,
+  )
+
+  const refinementInFlight = $derived(
+    session?.refinement_status === RefinementStatus.Pending ||
+      session?.refinement_status === RefinementStatus.Running,
+  )
+
+  type View = 'refined' | 'segments'
+  // Default to refined view whenever a refined transcript is available.
+  let view = $state<View>('segments')
+  $effect(() => {
+    if (refinementCompleted) {
+      view = 'refined'
+    } else {
+      view = 'segments'
+    }
+  })
+
+  function segmentsAsText(): string {
+    return segments
       .map((s) => `[${prettyTime(s.start_time)}] Speaker ${s.speaker}: ${s.text}`)
       .join('\n')
+  }
+
+  async function copyTranscript() {
+    const text = view === 'refined' && refinedText ? refinedText : segmentsAsText()
     const ok = await copyText(text)
     if (ok) {
       transcriptCopied = true
@@ -132,21 +171,56 @@
 
   <div class="transcript-header">
     <span class="transcript-label">Transcript</span>
-    <button type="button" class="copy-btn" onclick={copyTranscript}>
-      {transcriptCopied ? 'Copied!' : 'Copy transcript'}
-    </button>
+    <div class="transcript-header-actions">
+      {#if refinementCompleted}
+        <div
+          class="transcript-toggle"
+          role="group"
+          aria-label="Transcript view"
+          data-testid="transcript-view-toggle"
+        >
+          <button
+            type="button"
+            class={`toggle-btn ${view === 'refined' ? 'active' : ''}`}
+            aria-pressed={view === 'refined'}
+            onclick={() => (view = 'refined')}
+          >
+            Refined
+          </button>
+          <button
+            type="button"
+            class={`toggle-btn ${view === 'segments' ? 'active' : ''}`}
+            aria-pressed={view === 'segments'}
+            onclick={() => (view = 'segments')}
+          >
+            Segments
+          </button>
+        </div>
+      {:else if refinementInFlight}
+        <span class="refining-indicator" data-testid="refining-indicator">Refining…</span>
+      {/if}
+      <button type="button" class="copy-btn" onclick={copyTranscript}>
+        {transcriptCopied ? 'Copied!' : 'Copy transcript'}
+      </button>
+    </div>
   </div>
 
-  <div class="transcript-sync">
-    {#each segments as segment, index (segment.timestamp + segment.text + index)}
-      <button
-        type="button"
-        class={`line ${index === activeSegmentIndex ? 'active' : ''}`}
-        onclick={() => seekTo(segment.start_time)}
-      >
-        <span class="line-time">{prettyTime(segment.start_time)}</span>
-        <span class="line-text">{segment.text}</span>
-      </button>
-    {/each}
-  </div>
+  {#if view === 'refined' && refinedText}
+    <div class="transcript-refined" data-testid="transcript-refined">
+      {refinedText}
+    </div>
+  {:else}
+    <div class="transcript-sync">
+      {#each segments as segment, index (segment.timestamp + segment.text + index)}
+        <button
+          type="button"
+          class={`line ${index === activeSegmentIndex ? 'active' : ''}`}
+          onclick={() => seekTo(segment.start_time)}
+        >
+          <span class="line-time">{prettyTime(segment.start_time)}</span>
+          <span class="line-text">{segment.text}</span>
+        </button>
+      {/each}
+    </div>
+  {/if}
 </div>

--- a/web/src/components/SessionCard.svelte
+++ b/web/src/components/SessionCard.svelte
@@ -332,7 +332,7 @@
   {#if expanded}
     <div class="session-details">
       {#if detail}
-        <AudioPlayer sessionId={session.id} segments={detail.segments} />
+        <AudioPlayer sessionId={session.id} segments={detail.segments} {session} />
 
         {#if session.summary_status === SummaryStatus.Completed && session.summary}
           <div class="summary-section">

--- a/web/src/components/__tests__/AudioPlayer.test.ts
+++ b/web/src/components/__tests__/AudioPlayer.test.ts
@@ -2,6 +2,23 @@ import { fireEvent, render, screen } from '@testing-library/svelte'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import AudioPlayer from '../AudioPlayer.svelte'
 import { appState, resetState } from '../../lib/state.svelte'
+import { RefinementStatus, SummaryStatus, type SessionSummary } from '../../lib/types'
+
+const writeText = vi.fn().mockResolvedValue(undefined)
+
+function makeSession(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 's1',
+    title: 'Test Session',
+    started_at: '2026-04-25T00:00:00Z',
+    status: 'ended',
+    summary: '',
+    summary_status: SummaryStatus.Completed,
+    summary_preset: 'standup',
+    audio_path: '/tmp/audio.mp3',
+    ...overrides,
+  }
+}
 
 describe('AudioPlayer', () => {
   beforeEach(() => {
@@ -13,6 +30,11 @@ describe('AudioPlayer', () => {
       configurable: true,
       value: vi.fn(),
     })
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    writeText.mockClear()
   })
 
   afterEach(() => {
@@ -40,5 +62,143 @@ describe('AudioPlayer', () => {
 
     await fireEvent.click(screen.getByRole('button', { name: /Hello/i }))
     expect(appState.activeAudioSessionId).toBe('s1')
+  })
+
+  it('shows refined transcript and view toggle when refinement completed', () => {
+    render(AudioPlayer, {
+      sessionId: 's1',
+      segments: [
+        {
+          speaker: 0,
+          text: 'raw streaming',
+          start_time: 0,
+          end_time: 2,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      session: makeSession({
+        refinement_status: RefinementStatus.Completed,
+        refined_transcript: 'Polished refined transcript text.',
+        canonical_transcript: 'Polished refined transcript text.',
+        transcript_source: 'refined',
+      }),
+    })
+
+    expect(screen.getByTestId('transcript-refined').textContent).toContain(
+      'Polished refined transcript text.',
+    )
+    expect(screen.getByTestId('transcript-view-toggle')).toBeTruthy()
+    // Streaming segment should NOT be visible by default
+    expect(screen.queryByText('raw streaming')).toBeNull()
+  })
+
+  it('switches to segments view when toggle clicked', async () => {
+    render(AudioPlayer, {
+      sessionId: 's1',
+      segments: [
+        {
+          speaker: 0,
+          text: 'raw streaming',
+          start_time: 0,
+          end_time: 2,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      session: makeSession({
+        refinement_status: RefinementStatus.Completed,
+        refined_transcript: 'Polished refined transcript text.',
+        transcript_source: 'refined',
+      }),
+    })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Segments' }))
+    expect(screen.getByText('raw streaming')).toBeTruthy()
+    expect(screen.queryByTestId('transcript-refined')).toBeNull()
+  })
+
+  it('falls back to segments view when refinement not completed', () => {
+    render(AudioPlayer, {
+      sessionId: 's1',
+      segments: [
+        {
+          speaker: 0,
+          text: 'raw streaming',
+          start_time: 0,
+          end_time: 2,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      session: makeSession({
+        refinement_status: RefinementStatus.Pending,
+      }),
+    })
+
+    expect(screen.getByText('raw streaming')).toBeTruthy()
+    expect(screen.queryByTestId('transcript-view-toggle')).toBeNull()
+    expect(screen.getByTestId('refining-indicator')).toBeTruthy()
+  })
+
+  it('copies refined transcript when refined view active', async () => {
+    render(AudioPlayer, {
+      sessionId: 's1',
+      segments: [
+        {
+          speaker: 0,
+          text: 'raw streaming',
+          start_time: 0,
+          end_time: 2,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      session: makeSession({
+        refinement_status: RefinementStatus.Completed,
+        refined_transcript: 'Polished refined transcript text.',
+        transcript_source: 'refined',
+      }),
+    })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Copy transcript' }))
+    expect(writeText).toHaveBeenCalledWith('Polished refined transcript text.')
+  })
+
+  it('copies segment-formatted transcript when in segments view', async () => {
+    render(AudioPlayer, {
+      sessionId: 's1',
+      segments: [
+        {
+          speaker: 0,
+          text: 'raw streaming',
+          start_time: 5,
+          end_time: 8,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+      session: makeSession({
+        refinement_status: RefinementStatus.Completed,
+        refined_transcript: 'Polished refined transcript text.',
+        transcript_source: 'refined',
+      }),
+    })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Segments' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'Copy transcript' }))
+    expect(writeText).toHaveBeenCalledWith('[00:05] Speaker 0: raw streaming')
+  })
+
+  it('uses canonical_transcript when source is refined and refined_transcript empty', () => {
+    render(AudioPlayer, {
+      sessionId: 's1',
+      segments: [],
+      session: makeSession({
+        refinement_status: RefinementStatus.Completed,
+        refined_transcript: '',
+        canonical_transcript: 'Canonical refined output.',
+        transcript_source: 'refined',
+      }),
+    })
+
+    expect(screen.getByTestId('transcript-refined').textContent).toContain(
+      'Canonical refined output.',
+    )
   })
 })

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -143,6 +143,8 @@ export interface SessionSummary {
   sync_status?: SyncStatus
   refinement_status?: RefinementStatus
   transcript_source?: string
+  refined_transcript?: string
+  canonical_transcript?: string
 }
 
 export interface SessionDetailResponse {


### PR DESCRIPTION
## Summary

After second-stage Deepgram refinement completes, the session UI now surfaces the polished refined transcript instead of only displaying the streaming segments. The Copy transcript button also picks up the refined version automatically.

## Behavior

- **Refinement completed** → AudioPlayer auto-switches to a **Refined** view rendering the polished prose. A small **Refined / Segments** toggle lets users flip back to the timestamped segment view (preserving click-to-seek during playback).
- **Refinement pending / running** → Segments view stays visible with a subtle **Refining…** indicator. Auto-swaps to refined when ready.
- **Refinement failed / not run** → Behaves exactly as before (segments only, no toggle, no indicator).
- **Copy transcript** copies whichever variant is currently shown: refined prose in refined view, timestamped segments in segments view.

## Field source

Prefers \`refined_transcript\`, falls back to \`canonical_transcript\` when \`transcript_source === 'refined'\`. This covers historical sessions where the backend canonicalized into \`canonical_transcript\` but \`refined_transcript\` may be empty. The backend already exposed both fields via \`GET /api/sessions/{id}\` — no API changes needed.

## Files changed

- \`web/src/lib/types.ts\` — added \`refined_transcript\` and \`canonical_transcript\` to \`SessionSummary\`
- \`web/src/components/AudioPlayer.svelte\` — refined-view rendering, view toggle, Refining… indicator, refined-aware copy
- \`web/src/components/SessionCard.svelte\` — passes \`session\` prop into \`AudioPlayer\`
- \`web/src/app.css\` — \`.transcript-toggle\`, \`.toggle-btn\`, \`.refining-indicator\`, \`.transcript-refined\` styles
- \`web/src/components/__tests__/AudioPlayer.test.ts\` — 6 new tests covering refined render, toggle switch, copy in both views, pending state, canonical fallback

## Verification

- \`npm run check\` → 0 errors (27 pre-existing warnings, none in changed files)
- \`npm test\` → **43/43 passing** (8/8 in AudioPlayer)
- \`npm run build\` → success
- Deployed via \`make deploy\` and verified live on http://localhost:8080